### PR TITLE
Preferred language

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,6 +11,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extensions",
                 "--extensionDevelopmentPath=${workspaceFolder}"
             ]
         },
@@ -20,6 +21,7 @@
             "request": "launch",
             "runtimeExecutable": "${execPath}",
             "args": [
+                "--disable-extensions",
                 "--extensionDevelopmentPath=${workspaceFolder}",
                 "--extensionTestsPath=${workspaceFolder}/test"
             ]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@ If the keyboard shortcut doesn't work for you, you have two options:
 
 * Open the command palette and manually select 'Translate selection(s)'
 * Open your keyboard shortcuts, search for 'Translate selection(s)' and set a new shortcut for this command.
+
+
+## Settings
+Want to quickly translate into a specific language?
+Here's how to set your preferred language to Japanese.
+
+1. Get your preferred language code from [the web](https://www.w3schools.com/tags/ref_language_codes.asp).
+1. Add the following setting to your workspace: ```"vscodeTranslate.preferredLanguage": "ja"```
+1. Then open the command palette and select "Translate selection(s) to preferred language".
+
+* This also works with multiple selections 👍
+* Add ( or re-bind ) a keyboard shortcut to "Translate selection(s) to preferred language" to translate even quicker 👍👍

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-google-translate",
-    "version": "1.1.4",
+    "version": "1.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Vscode Google Translate",
     "description": "Translate text right in your code",
     "publisher": "funkyremi",
-    "version": "1.1.5",
+    "version": "1.2.0",
     "icon": "icon.png",
     "repository": {
         "type": "git",
@@ -16,7 +16,8 @@
         "Formatters"
     ],
     "activationEvents": [
-        "onCommand:extension.translateText"
+        "onCommand:extension.translateText",
+        "onCommand:extension.translateTextPreferred"
     ],
     "main": "./extension",
     "contributes": {
@@ -24,8 +25,22 @@
             {
                 "command": "extension.translateText",
                 "title": "Translate selection(s)"
+            },
+            {
+                "command": "extension.translateTextPreferred",
+                "title": "Translate selection(s) to preferred language"
             }
-        ]
+        ],
+        "configuration": {
+            "type": "object",
+            "properties": {
+                "vscodeTranslate.preferredLanguage": {
+                    "type": "string",
+                    "default": false,
+                    "description": "Your preferred language setting in standard 2-char language Code Reference code"
+                }
+            }
+        }
     },
     "keybindings": [
         {


### PR DESCRIPTION
This adds a "Translate selection(s) to preferred language" command.

Users should save a 2-character language code to their settings file.
When a user selects "Translate selection(s) to preferred language" command, it gets the preferred language  setting and translates into this language. If no language is set (default), nothing happens.

Readme file has been updated with instructions. Version was bumped.

As outlined in #3 
