### PR TITLE
Show toast messages for errors

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -95,7 +95,7 @@ function getTranslationPromise(
           reject(new Error("Google Translation API issue"));
         }
       })
-      .catch(e => reject(new Error("Google Translation API issue")));
+      .catch(e => reject(new Error("Google Translation API issue: " + e.message)));
   });
 }
 
@@ -187,10 +187,10 @@ function activate(context) {
                 });
               });
             })
-            .catch(e => vscode.window.showErrorMessage(e));
+            .catch(e => vscode.window.showErrorMessage(e.message));
         })
         .catch(err => {
-          vscode.window.showErrorMessage(err);
+          vscode.window.showErrorMessage(err.message);
         });
     }
   );
@@ -223,7 +223,7 @@ function activate(context) {
             });
           });
         })
-        .catch(e => vscode.window.showErrorMessage(e));
+        .catch(e => vscode.window.showErrorMessage(e.message));
     }
   );
   context.subscriptions.push(translateTextPreferred);
@@ -271,10 +271,10 @@ function activate(context) {
                 });
               });
             })
-            .catch(e => vscode.window.showErrorMessage(e));
+            .catch(e => vscode.window.showErrorMessage(e.message));
         })
         .catch(err => {
-          vscode.window.showErrorMessage(err);
+          vscode.window.showErrorMessage(err.message);
         });
     }
   );
@@ -314,7 +314,7 @@ function activate(context) {
             });
           });
         })
-        .catch(e => vscode.window.showErrorMessage(e));
+        .catch(e => vscode.window.showErrorMessage(e.message));
     }
   );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-google-translate",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
This PR should fix: https://github.com/funkyremi/vscode-google-translate/issues/13.  Looks like the issue was showErrorMessage does not accept error, rather it requires a string.  Also, I included the error message from Google API error into toast message.

The toast looks like this:

![image](https://user-images.githubusercontent.com/40151580/64060890-f0a6d680-cb87-11e9-8a39-285d349058e4.png)
