### PR TITLE
Improve Accessibility by Removing need to know country code. Fix Shortcut as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Quickly translate text right in your code 🚀
 ### Translate selected text
 
 1. Select some text to translate
-1. Press `ALT+SHIFT+T`
+1. Press `CTRL+ALT+T`
 1. Select the output languages you want and enjoy 👍
 
 ### Translate a line under cursor
@@ -23,21 +23,10 @@ This feature inserts a newline under the current one with translation
 1. Select menu 'Translate line(s) under the cursor'
 1. Select the output languages you want and enjoy
 
-## Keyboard shortcut
-
-If the keyboard shortcut doesn't work for you, you have two options:
-
-* Open the command palette and manually select 'Translate selection(s)'
-* Open your keyboard shortcuts, search for 'Translate selection(s)' and set a new shortcut for this command.
-
 ## Preferred language settings
 
 Want to quickly translate into a specific language?
-Here's how to set your preferred language to Japanese.
-
-1. Get your preferred language code from [the web](https://www.w3schools.com/tags/ref_language_codes.asp).
-1. Add the following setting to your workspace: `"vscodeGoogleTranslate.preferredLanguage": "ja"`
-1. Open the command palette and select "Translate selection(s) to preferred language".
+Run Command 'Set Preferred Language' or Set it in VSCode extension settings
 
 ## Proxy Support
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Quickly translate text right in your code 🚀
 ### Translate selected text
 
 1. Select some text to translate
-1. Press `CTRL+ALT+T`
+1. Press `ALT+SHIFT+T`
 1. Select the output languages you want and enjoy 👍
 
 ### Translate a line under cursor

--- a/extension.js
+++ b/extension.js
@@ -233,7 +233,7 @@ function activate(context) {
       const { document, selections } = editor;
 
       // vscodeTranslate.preferredLanguage
-      let locale = getPreferredLanguage();
+      let locale = languages.find(element => element.name === getPreferredLanguage()).value;
       if (!locale) {
         return;
       }
@@ -316,7 +316,7 @@ function activate(context) {
     function translateLinesUnderCursorPreferredcallback() {
       const editor = vscode.window.activeTextEditor;
       const { document, selections } = editor;
-      let locale = getPreferredLanguage();
+      let locale = languages.find(element => element.name === getPreferredLanguage()).value;
       if (!locale) {
         vscode.window.showWarningMessage(
           "Prefered language is requeried for this feature! Please set this in the settings."

--- a/extension.js
+++ b/extension.js
@@ -226,6 +226,30 @@ function activate(context) {
   );
   context.subscriptions.push(translateText);
 
+  let setPreferredLanguage = vscode.commands.registerCommand(
+    "extension.setPreferredLanguage",
+    function() {
+      const editor = vscode.window.activeTextEditor;
+      const { document, selections } = editor;
+
+      const quickPickData = recentlyUsed
+        .map(r => ({
+          name: r.name.includes("(recently used)")
+            ? r.name
+            : `${r.name} (recently used)`,
+          value: r.value
+        }))
+        .concat(languages);
+
+      vscode.window
+        .showQuickPick(quickPickData.map(l => l.name))
+        .then(res => {
+          vscode.workspace.getConfiguration().update("vscodeGoogleTranslate.preferredLanguage", res, vscode.ConfigurationTarget.Global);
+        })
+    }
+  )
+  context.subscriptions.push(setPreferredLanguage);
+
   let translateTextPreferred = vscode.commands.registerCommand(
     "extension.translateTextPreferred",
     function() {

--- a/extension.js
+++ b/extension.js
@@ -146,14 +146,10 @@ function getTranslationsPromiseArrayLine(
  * If user hasn't set preferred lang. Prompt to set.
  */
 async function getPreferredLanguage() {
-  var pref = vscode.workspace
+  return vscode.workspace
     .getConfiguration("vscodeGoogleTranslate")
-    .get("preferredLanguage");
-
-  if (!pref) {
-    return setPreferredLanguage()
-  }
-  return pref;
+    .get("preferredLanguage")
+    || setPreferredLanguage();
 }
 
 function setPreferredLanguage() {
@@ -200,7 +196,7 @@ function getProxyConfig() {
  */
 function activate(context) {
   let translateText = vscode.commands.registerCommand(
-    "vscodeGoogleTranslate.translateText",
+    "extension.translateText",
     function() {
       const editor = vscode.window.activeTextEditor;
       const { document, selections } = editor;
@@ -241,11 +237,11 @@ function activate(context) {
   );
   context.subscriptions.push(translateText);
 
-  let setPreferredLanguageFnc = vscode.commands.registerCommand("vscodeGoogleTranslate.setPreferredLanguage", setPreferredLanguage);
+  let setPreferredLanguageFnc = vscode.commands.registerCommand("extension.setPreferredLanguage", setPreferredLanguage);
   context.subscriptions.push(setPreferredLanguageFnc);
 
   let translateTextPreferred = vscode.commands.registerCommand(
-    "vscodeGoogleTranslate.translateTextPreferred",
+    "extension.translateTextPreferred",
     async function() {
       const editor = vscode.window.activeTextEditor;
       const { document, selections } = editor;
@@ -278,7 +274,7 @@ function activate(context) {
   context.subscriptions.push(translateTextPreferred);
 
   let translateLinesUnderCursor = vscode.commands.registerCommand(
-    "vscodeGoogleTranslate.translateLinesUnderCursor",
+    "extension.translateLinesUnderCursor",
     function translateLinesUnderCursorcallback() {
       const editor = vscode.window.activeTextEditor;
       const { document, selections } = editor;
@@ -328,11 +324,11 @@ function activate(context) {
   context.subscriptions.push(translateLinesUnderCursor);
 
   let translateLinesUnderCursorPreferred = vscode.commands.registerCommand(
-    "vscodeGoogleTranslate.translateLinesUnderCursorPreferred",
+    "extension.translateLinesUnderCursorPreferred",
     async function translateLinesUnderCursorPreferredcallback() {
       const editor = vscode.window.activeTextEditor;
       const { document, selections } = editor;
-      var preferredLanguage = await getPreferredLanguage();
+      let preferredLanguage = await getPreferredLanguage();
       let locale = languages.find(element => element.name === preferredLanguage).value;
       if (!locale) {
         vscode.window.showWarningMessage(

--- a/extension.js
+++ b/extension.js
@@ -2,7 +2,6 @@ const vscode = require("vscode");
 const languages = require("./languages.js");
 const translate = require("google-translate-open-api").default;
 const he = require("he");
-const { get } = require("https");
 
 /**
  * @typedef TranslateRes

--- a/package.json
+++ b/package.json
@@ -48,23 +48,25 @@
             "properties": {
                 "vscodeGoogleTranslate.preferredLanguage": {
                     "type": "string",
-                    "description": "The preferred language setting in standard 2-char language Code Reference code"
+                    "default": "Spanish",
+                    "enum": ["Afrikaans", "Albanian", "Amharic", "Arabic", "Armenian", "Azeerbaijani", "Basque", "Belarusian", "Bengali", "Bosnian", "Bulgarian", "Catalan", "Cebuano", "Chinese (Simplified)", "Chinese (Traditional)", "Corsican", "Croatian", "Czech", "Danish", "Dutch", "English", "Esperanto", "Estonian", "Finnish", "French", "Frisian", "Galician", "Georgian", "German", "Greek", "Gujarati", "Haitian Creole", "Hausa", "Hawaiian", "Hebrew", "Hindi", "Hmong", "Hungarian", "Icelandic", "Igbo", "Indonesian", "Irish", "Italian", "Japanese", "Javanese", "Kannada", "Kazakh", "Khmer", "Korean", "Kurdish", "Kyrgyz", "Lao", "Latin", "Latvian", "Lithuanian", "Luxembourgish", "Macedonian", "Malagasy", "Malay", "Malayalam", "Maltese", "Maori", "Marathi", "Mongolian", "Myanmar", "Nepali", "Norwegian", "Nyanja", "Pashto", "Persian", "Polish", "Portuguese", "Punjabi", "Romanian", "Russian", "Samoan", "Scots Gaelic", "Serbian", "Sesotho", "Shona", "Sindhi", "Sinhala", "Slovak", "Slovenian", "Somali", "Spanish", "Sundanese", "Swahili", "Swedish", "Tagalog", "Tajik", "Tamil", "Telugu", "Thai", "Turkish", "Ukrainian", "Urdu", "Uyghur", "Uzbek", "Vietnamese", "Welsh", "Xhosa", "Yiddish", "Yoruba", "Zulu"],
+                    "description": "The preferred language"
                 },
                 "vscodeGoogleTranslate.proxyHost": {
                     "type": "string",
-                    "description": "The proxy host (set it to enable proxy)"
+                    "description": "The proxy host (set it to enable proxy) (Optional)"
                 },
                 "vscodeGoogleTranslate.proxyPort": {
                     "type": "string",
-                    "description": "The proxy port"
+                    "description": "The proxy port (Optional)"
                 },
                 "vscodeGoogleTranslate.proxyUsername": {
                     "type": "string",
-                    "description": "The proxy username (optional)"
+                    "description": "The proxy username (Optional)"
                 },
                 "vscodeGoogleTranslate.proxyPassword": {
                     "type": "string",
-                    "description": "The proxy password (optional)"
+                    "description": "The proxy password (Optional)"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     },
     "keybindings": [
         {
-            "key": "alt+shit+t",
+            "key": "alt+shift+t",
             "command": "extension.translateText"
         }
     ],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     ],
     "activationEvents": [
         "onCommand:extension.translateText",
+        "onCommand:extension.setPreferredLanguage",
         "onCommand:extension.translateTextPreferred",
         "onCommand:extension.translateLinesUnderCursor",
         "onCommand:extension.translateLinesUnderCursorPreferred"
@@ -38,6 +39,10 @@
                 "title": "Translate line(s) under the cursor"
             },
             {
+                "command": "extension.setPreferredLanguage",
+                "title": "Set preferred target language"
+            },
+            {
                 "command": "extension.translateLinesUnderCursorPreferred",
                 "title": "Translate line(s) under the cursor to preferred language"
             }
@@ -50,7 +55,7 @@
                     "type": "string",
                     "default": "Spanish",
                     "enum": ["Afrikaans", "Albanian", "Amharic", "Arabic", "Armenian", "Azeerbaijani", "Basque", "Belarusian", "Bengali", "Bosnian", "Bulgarian", "Catalan", "Cebuano", "Chinese (Simplified)", "Chinese (Traditional)", "Corsican", "Croatian", "Czech", "Danish", "Dutch", "English", "Esperanto", "Estonian", "Finnish", "French", "Frisian", "Galician", "Georgian", "German", "Greek", "Gujarati", "Haitian Creole", "Hausa", "Hawaiian", "Hebrew", "Hindi", "Hmong", "Hungarian", "Icelandic", "Igbo", "Indonesian", "Irish", "Italian", "Japanese", "Javanese", "Kannada", "Kazakh", "Khmer", "Korean", "Kurdish", "Kyrgyz", "Lao", "Latin", "Latvian", "Lithuanian", "Luxembourgish", "Macedonian", "Malagasy", "Malay", "Malayalam", "Maltese", "Maori", "Marathi", "Mongolian", "Myanmar", "Nepali", "Norwegian", "Nyanja", "Pashto", "Persian", "Polish", "Portuguese", "Punjabi", "Romanian", "Russian", "Samoan", "Scots Gaelic", "Serbian", "Sesotho", "Shona", "Sindhi", "Sinhala", "Slovak", "Slovenian", "Somali", "Spanish", "Sundanese", "Swahili", "Swedish", "Tagalog", "Tajik", "Tamil", "Telugu", "Thai", "Turkish", "Ukrainian", "Urdu", "Uyghur", "Uzbek", "Vietnamese", "Welsh", "Xhosa", "Yiddish", "Yoruba", "Zulu"],
-                    "description": "The preferred language"
+                    "description": "The preferred target language"
                 },
                 "vscodeGoogleTranslate.proxyHost": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -17,33 +17,33 @@
         "Formatters"
     ],
     "activationEvents": [
-        "onCommand:extension.translateText",
-        "onCommand:extension.setPreferredLanguage",
-        "onCommand:extension.translateTextPreferred",
-        "onCommand:extension.translateLinesUnderCursor",
-        "onCommand:extension.translateLinesUnderCursorPreferred"
+        "onCommand:vscodeGoogleTranslate.translateText",
+        "onCommand:vscodeGoogleTranslate.setPreferredLanguage",
+        "onCommand:vscodeGoogleTranslate.translateTextPreferred",
+        "onCommand:vscodeGoogleTranslate.translateLinesUnderCursor",
+        "onCommand:vscodeGoogleTranslate.translateLinesUnderCursorPreferred"
     ],
     "main": "./extension",
     "contributes": {
         "commands": [
             {
-                "command": "extension.translateText",
+                "command": "vscodeGoogleTranslate.translateText",
                 "title": "Translate selection(s)"
             },
             {
-                "command": "extension.translateTextPreferred",
+                "command": "vscodeGoogleTranslate.translateTextPreferred",
                 "title": "Translate selection(s) to preferred language"
             },
             {
-                "command": "extension.translateLinesUnderCursor",
+                "command": "vscodeGoogleTranslate.translateLinesUnderCursor",
                 "title": "Translate line(s) under the cursor"
             },
             {
-                "command": "extension.setPreferredLanguage",
+                "command": "vscodeGoogleTranslate.setPreferredLanguage",
                 "title": "Set preferred target language"
             },
             {
-                "command": "extension.translateLinesUnderCursorPreferred",
+                "command": "vscodeGoogleTranslate.translateLinesUnderCursorPreferred",
                 "title": "Translate line(s) under the cursor to preferred language"
             }
         ],
@@ -53,7 +53,6 @@
             "properties": {
                 "vscodeGoogleTranslate.preferredLanguage": {
                     "type": "string",
-                    "default": "Spanish",
                     "enum": ["Afrikaans", "Albanian", "Amharic", "Arabic", "Armenian", "Azeerbaijani", "Basque", "Belarusian", "Bengali", "Bosnian", "Bulgarian", "Catalan", "Cebuano", "Chinese (Simplified)", "Chinese (Traditional)", "Corsican", "Croatian", "Czech", "Danish", "Dutch", "English", "Esperanto", "Estonian", "Finnish", "French", "Frisian", "Galician", "Georgian", "German", "Greek", "Gujarati", "Haitian Creole", "Hausa", "Hawaiian", "Hebrew", "Hindi", "Hmong", "Hungarian", "Icelandic", "Igbo", "Indonesian", "Irish", "Italian", "Japanese", "Javanese", "Kannada", "Kazakh", "Khmer", "Korean", "Kurdish", "Kyrgyz", "Lao", "Latin", "Latvian", "Lithuanian", "Luxembourgish", "Macedonian", "Malagasy", "Malay", "Malayalam", "Maltese", "Maori", "Marathi", "Mongolian", "Myanmar", "Nepali", "Norwegian", "Nyanja", "Pashto", "Persian", "Polish", "Portuguese", "Punjabi", "Romanian", "Russian", "Samoan", "Scots Gaelic", "Serbian", "Sesotho", "Shona", "Sindhi", "Sinhala", "Slovak", "Slovenian", "Somali", "Spanish", "Sundanese", "Swahili", "Swedish", "Tagalog", "Tajik", "Tamil", "Telugu", "Thai", "Turkish", "Ukrainian", "Urdu", "Uyghur", "Uzbek", "Vietnamese", "Welsh", "Xhosa", "Yiddish", "Yoruba", "Zulu"],
                     "description": "The preferred target language"
                 },
@@ -79,7 +78,7 @@
             {
                 "key": "ctrl+alt+t",
                 "when": "editorTextFocus",
-                "command": "extension.translateTextPreferred"
+                "command": "vscodeGoogleTranslate.translateTextPreferred"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -17,33 +17,33 @@
         "Formatters"
     ],
     "activationEvents": [
-        "onCommand:vscodeGoogleTranslate.translateText",
-        "onCommand:vscodeGoogleTranslate.setPreferredLanguage",
-        "onCommand:vscodeGoogleTranslate.translateTextPreferred",
-        "onCommand:vscodeGoogleTranslate.translateLinesUnderCursor",
-        "onCommand:vscodeGoogleTranslate.translateLinesUnderCursorPreferred"
+        "onCommand:extension.translateText",
+        "onCommand:extension.setPreferredLanguage",
+        "onCommand:extension.translateTextPreferred",
+        "onCommand:extension.translateLinesUnderCursor",
+        "onCommand:extension.translateLinesUnderCursorPreferred"
     ],
     "main": "./extension",
     "contributes": {
         "commands": [
             {
-                "command": "vscodeGoogleTranslate.translateText",
+                "command": "extension.translateText",
                 "title": "Translate selection(s)"
             },
             {
-                "command": "vscodeGoogleTranslate.translateTextPreferred",
+                "command": "extension.translateTextPreferred",
                 "title": "Translate selection(s) to preferred language"
             },
             {
-                "command": "vscodeGoogleTranslate.translateLinesUnderCursor",
+                "command": "extension.translateLinesUnderCursor",
                 "title": "Translate line(s) under the cursor"
             },
             {
-                "command": "vscodeGoogleTranslate.setPreferredLanguage",
+                "command": "extension.setPreferredLanguage",
                 "title": "Set preferred target language"
             },
             {
-                "command": "vscodeGoogleTranslate.translateLinesUnderCursorPreferred",
+                "command": "extension.translateLinesUnderCursorPreferred",
                 "title": "Translate line(s) under the cursor to preferred language"
             }
         ],
@@ -76,9 +76,9 @@
         },
         "keybindings": [
             {
-                "key": "ctrl+alt+t",
+                "key": "alt+shift+t",
                 "when": "editorTextFocus",
-                "command": "vscodeGoogleTranslate.translateTextPreferred"
+                "command": "extension.translateTextPreferred"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -74,14 +74,15 @@
                     "description": "The proxy password (Optional)"
                 }
             }
-        }
+        },
+        "keybindings": [
+            {
+                "key": "ctrl+alt+t",
+                "when": "editorTextFocus",
+                "command": "extension.translateTextPreferred"
+            }
+        ]
     },
-    "keybindings": [
-        {
-            "key": "alt+shift+t",
-            "command": "extension.translateText"
-        }
-    ],
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install",
         "test": "node ./node_modules/vscode/bin/test"


### PR DESCRIPTION
One thing I noticed instantly was the difficulty to set a default language in settings. I exposed a command that uses a quick pick as well as an enum in the actual setting to make that a lot easier. In the process I made the languages list a bit more static and removed the need to append "(recently used)" to the name.

Please get in touch ASAP if you have any questions. I'm excited to contribute back :)