### PR TITLE
Translate Text Not Separated By Spaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -222,6 +222,11 @@
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true
         },
+        "camelcase": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+            "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
+        },
         "capture-stack-trace": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
@@ -374,6 +379,14 @@
             "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
             "requires": {
                 "ms": "^2.1.1"
+            }
+        },
+        "decamelize": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+            "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+            "requires": {
+                "xregexp": "4.0.0"
             }
         },
         "deep-is": {
@@ -856,6 +869,14 @@
             "requires": {
                 "agent-base": "^4.3.0",
                 "debug": "^3.1.0"
+            }
+        },
+        "humanize-string": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-2.1.0.tgz",
+            "integrity": "sha512-sQ+hqmxyXW8Cj7iqxcQxD7oSy3+AXnIZXdUF9lQMkzaG8dtbKAB8U7lCtViMnwQ+MpdCKsO2Kiij3G6UUXq/Xg==",
+            "requires": {
+                "decamelize": "^2.0.0"
             }
         },
         "iconv-lite": {
@@ -1893,6 +1914,11 @@
             "requires": {
                 "os-homedir": "^1.0.0"
             }
+        },
+        "xregexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+            "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,9 @@
         "vscode": "^1.1.36"
     },
     "dependencies": {
+        "camelcase": "^6.0.0",
         "google-translate-open-api": "^1.3.3",
-        "he": "^1.2.0"
+        "he": "^1.2.0",
+        "humanize-string": "^2.1.0"
     }
 }


### PR DESCRIPTION
This used the Npm package humanize to turn text that is separated by spaces into human readable text.
"fooBarBaz" => "Foo bar baz"
"foo_bar_baz" => "Foo bar baz"

And then it translates it and recombines it to camel case. this is a KNOWN ISSUE, if you have foo_bar_baz you will end up with fooBarBaz. I feel like this is an acceptable limitation. I could consider contributing to the humanize package. It would be awesome if it gave you a return value that represented the separation style so that we could translate and then replace with the appropriate casing.