### PR TITLE
Allocation the translation module. Fix hover translation 403

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,38 +1,11 @@
 const vscode = require("vscode");
 const languages = require("./languages.js");
-const gti = require("google-translate-api");
-const tunnel = require('tunnel');
-
-// Manual bridge between two libraries
-function translate(text, options) {
-  const gotopts = {};
-  if (options && options.proxy) {
-    const proxy = {
-      host: options.proxy.host,
-      port: options.proxy.port,
-      headers: {
-        "User-Agent": "Node",
-      },
-    };
-    if (options.proxy.auth) {
-      proxy.proxyAuth = `${options.proxy.auth.username}:${options.proxy.auth.password}`;
-    }
-
-    gotopts.agent = tunnel.httpsOverHttp({
-      proxy: proxy,
-    });
-  }
-  return gti(text, options, gotopts).then((res) => {
-    res.data = [res.text];
-    return res;
-  });
-}
-
 const he = require("he");
 const path = require("path");
 const vscodeLanguageClient = require("vscode-languageclient");
 const humanizeString = require("humanize-string");
 const camelcase = require("camelcase");
+const translate = require("./translator").translate;
 
 /**
  * @typedef TranslateRes
@@ -436,7 +409,7 @@ async function activate(context) {
 
   // All Below code initializes the Comment Hovering Translation feature
   let serverModule = context.asAbsolutePath(
-    path.join("server", "out", "server.js")
+    path.join("server", "out", "server","src", "server.js")
   );
   // The debug options for the server
   // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging

--- a/server/src/Comment.ts
+++ b/server/src/Comment.ts
@@ -2,8 +2,8 @@ import { TextDocumentPositionParams, Hover, TextDocuments, Connection, TextDocum
 import * as humanizeString from 'humanize-string';
 import { CommentParse, ICommentOption, ICommentBlock } from "./syntax/CommentParse";
 import { TextMateService } from "./syntax/TextMateService";
-import translate from "google-translate-open-api";
-import * as languages from "../../languages"
+import { translate } from "../../translator";
+import languages = require( "../../languages")
 
 
 export interface ICommentTranslateSettings {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -4,9 +4,10 @@
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"sourceMap": true,
+		"rootDir": "./../",
 		"outDir": "out",
-		"rootDir": "src",
-		"lib": [ "es6" ]
+		"lib": [ "es6" ],
+		"allowJs": true
 	},
 	"include": [
 		"src"

--- a/translator/google-api.js
+++ b/translator/google-api.js
@@ -1,0 +1,3 @@
+exports.translate = function () {
+  throw new Error("Google Translate API isn't supported yet!");
+};

--- a/translator/google-translate-api.js
+++ b/translator/google-translate-api.js
@@ -1,0 +1,34 @@
+const gtoa = require("google-translate-api");
+const tunnel = require("tunnel");
+
+/**
+ * Implement the google-translate-open-api interface
+ * @see {@link https://github.com/hua1995116/google-translate-open-api#translatetext-options}
+ * @param {string} text
+ * @param {object} options google-translate-open-api translate options
+ */
+function translate(text, options) {
+  const gotopts = {};
+  if (options && options.proxy) {
+    const proxy = {
+      host: options.proxy.host,
+      port: options.proxy.port,
+      headers: {
+        "User-Agent": "Node",
+      },
+    };
+    if (options.proxy.auth) {
+      proxy.proxyAuth = `${options.proxy.auth.username}:${options.proxy.auth.password}`;
+    }
+
+    gotopts.agent = tunnel.httpsOverHttp({
+      proxy: proxy,
+    });
+  }
+  return gtoa(text, options, gotopts).then((res) => {
+    res.data = [res.text];
+    return res;
+  });
+}
+
+module.exports.translate = translate;

--- a/translator/google-translate-open-api.js
+++ b/translator/google-translate-open-api.js
@@ -1,0 +1,3 @@
+exports.translate = function () {
+  throw new Error("The module google-translate-open-api isn't supported temporarily!");
+};

--- a/translator/index.js
+++ b/translator/index.js
@@ -1,0 +1,34 @@
+const ga = require("./google-api");
+const gtoa = require("./google-translate-open-api");
+const gta = require("./google-translate-api");
+
+/**
+ * Enum for translators modules
+ * @readonly
+ * @enum {number}
+ */
+const VSGT_MODULE = {
+  GA: 1,
+  GTA: 2,
+  GTOA: 3,
+};
+
+/**
+ * @typedef {Object} VSGTParams
+ * @property {VSGT_MODULE} module
+ * @property {object} options
+ */
+
+/**
+ * The following function is very important.
+ * It represents the beginning of the API for this application.
+ *
+ * @param {string} text for translation
+ * @param {VSGTParams|object} params
+ */
+function translate(text, params) {
+  const module = VSGT_MODULE.GTA || params.module; // Only the google-translate-api module is used now
+  if (true || module === 2) return gta.translate(text, params);
+}
+
+module.exports.translate = translate;

--- a/translator/test.js
+++ b/translator/test.js
@@ -1,0 +1,5 @@
+const t = require("./");
+
+(async () => {
+  console.log(await t.translate("test", { to: "ru" }));
+})();


### PR DESCRIPTION
- Allocation the translation module
- Fix hover translation 403

According https://github.com/funkyremi/vscode-google-translate/issues/14#issuecomment-753410290 it adds a wrapper interface for manipulating translators in general.

The fix hover translation is a demo of this also.
![1610086435121](https://user-images.githubusercontent.com/5027939/103981191-66667d80-5192-11eb-820e-c4bbc673c743.png)
